### PR TITLE
Remove hard version dependency for node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
 		"url": "git://github.com:alanshaw/grunt-include-replace.git"
 	},
 	"engines": {
-		"node": "~0.8.15"
+		"node": ">= 0.8.0"
 	}
 }


### PR DESCRIPTION
Since 0.10 is out, the current setting will through warnings for users on the newer version.
