### PR TITLE
Fixed infinite loop when replacement file contains "$&" characters

### DIFF
--- a/tasks/includereplace.js
+++ b/tasks/includereplace.js
@@ -119,7 +119,9 @@ module.exports = function(grunt) {
 					includeContents = options.processIncludeContents(includeContents, localVars);
 				}
 				
-				contents = contents.replace(match, includeContents);
+				contents = contents.replace(match, function () {
+					return includeContents;
+				});
 				
 				matches = includeRegExp.exec(contents);
 			}


### PR DESCRIPTION
Got an infinite loop on include of file with "$&". To prevent this, used function argument to String.replace.
