### PR TITLE
Missing comma after options: {} in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ grunt.initConfig({
     your_target: {
       options: {
         // Task-specific options go here.
-      }
+      },
       // Files to perform replacements and includes with
       src: '*.html',
       // Destination directory to copy files to


### PR DESCRIPTION
Results in the following error when running Grunt:

src: '*.html', // Files to perform replacements and includes with
^^^
Loading "Gruntfile.js" tasks...ERROR

> > SyntaxError: Unexpected identifier
