### PR TITLE
Resolve issue #53

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Default value: `.`
 
 `@@docroot` is a magic local variable that contains the relative path from the file that uses it to the path specified.
 
+#### options.encoding
+Type: `String`  
+Default value: `utf-8`
+
+Encoding files are using.
+
 #### options.processIncludeContents
 Type: `Function`  
 Default value: undefined

--- a/tasks/includereplace.js
+++ b/tasks/includereplace.js
@@ -20,10 +20,14 @@ module.exports = function(grunt) {
 			suffix: '',
 			globals: {},
 			includesDir: '',
-			docroot: '.'
+			docroot: '.',
+			encoding: 'utf-8'
 		});
 
 		grunt.log.debug('Options', options);
+
+		// Preset default encofing as early as possible
+		grunt.file.defaultEncoding = options.encoding;
 
 		// Variables available in ALL files
 		var globalVars = options.globals;


### PR DESCRIPTION
Add an option `encoding`. For example:

````
		includereplace: {
			your_target: {
				options: {
					encoding: 'gbk'
				},
				files: [{
					expand: true,
					flatten: true,
					cwd: 'dev/tmpl/',
					src: ['*.html', '!*.inc'],
					dest: 'html/',
				}]
			}
		}
````

This will make the output files with GBK encoding.