### PR TITLE
Fixed typographical error, changed availabe to available in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ grunt.initConfig({
 Type: `Object`  
 Default value: `{}`
 
-Global variables availabe for replacement in all files.
+Global variables available for replacement in all files.
 
 #### options.prefix
 Type: `String`  


### PR DESCRIPTION
alanshaw, I've corrected a typographical error in the documentation of the [grunt-include-replace](https://github.com/alanshaw/grunt-include-replace) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.