### PR TITLE
add ignoreLocalVars option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Default: `undefined`
 
 A function called for every included file prior to processing by `grunt-include-replace`. It is passed the include file contents, local variables and the file path as parameters and should return the (possibly altered) file contents.
 
+#### options.ignoreLocalVars
+Type: `Boolean`  
+Default: false
+
+Ignore parsing local variables within `include` expression while replacing. This is because that sometimes we don't know the values of local variables, and the template shall be used later with other template engine/method
+
 ### Usage Examples
 
 #### Default Options

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-include-replace",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Grunt task to include files and replace variables. Allows for parameterised includes.",
   "author": "Alan Shaw <alan138@gmail.com>",
   "license": "MIT",

--- a/tasks/includereplace.js
+++ b/tasks/includereplace.js
@@ -16,7 +16,8 @@ module.exports = function (grunt) {
       globals: {},
       includesDir: '',
       docroot: '.',
-      encoding: 'utf-8'
+      encoding: 'utf-8',
+      ignoreLocalVars: false
     })
 
     grunt.log.debug('Options', options)
@@ -113,7 +114,13 @@ module.exports = function (grunt) {
       while (matches) {
         var match = matches[0]
         var includePath = matches[1]
-        var localVars = matches[3] ? JSON.parse(matches[3]) : {}
+        var localVars
+
+        if (!options.ignoreLocalVars) {
+          localVars = matches[3] ? JSON.parse(matches[3]) : {}
+        } else {
+          localVars = {}
+        }
 
         if (!grunt.file.isPathAbsolute(includePath)) {
           includePath = path.resolve(path.join((options.includesDir ? options.includesDir : workingDir), includePath))


### PR DESCRIPTION
Sometimes, we don't have the value of `localVars`, and they shall be provided while later use.

So i added an option to ignore parsing `localVars`
