### PR TITLE
fix: Include file(s) not found error on Windows updated Grunt 1.6.0

### DIFF
--- a/tasks/includereplace.js
+++ b/tasks/includereplace.js
@@ -84,7 +84,7 @@ module.exports = function (grunt) {
       }
 
       function getIncludeContents (includePath, localVars) {
-        var files = grunt.file.expand(includePath)
+        var files = grunt.file.expand( { windowsPathsNoEscape : (process.platform === 'win32') }, includePath)
         var includeContents = ''
 
         // If files is not an array of at least one element then bad


### PR DESCRIPTION
fixed #83 

## Solution
Use `windowsPathsNoEscape` option when using `grunt.file.expand`. (only Windows)